### PR TITLE
fix: 修复中文编码导致保存docx失败BUG

### DIFF
--- a/swcr/swcr.py
+++ b/swcr/swcr.py
@@ -164,7 +164,7 @@ class CodeWriter(object):
         """
         把单个文件添加到程序文档里面
         """
-        with open(file) as fp:
+        with open(file, encoding='utf-8') as fp:
             for line in fp:
                 line = line.rstrip()
                 if self.is_blank_line(line):


### PR DESCRIPTION
Traceback (most recent call last):
  File "swcr.py", line 285, in <module>
    main()
  File "C:\Users\zz\Desktop\tmp\swcr\venv\lib\site-packages\click\core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\zz\Desktop\tmp\swcr\venv\lib\site-packages\click\core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "C:\Users\zz\Desktop\tmp\swcr\venv\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\zz\Desktop\tmp\swcr\venv\lib\site-packages\click\core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "swcr.py", line 279, in main
    writer.write_file(file)
  File "swcr.py", line 168, in write_file
    for line in fp:
UnicodeDecodeError: 'gbk' codec can't decode byte 0xa8 in position 239: illegal multibyte sequence
